### PR TITLE
Role assignment correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ python convert.py --dataset split_to_convert --hptr_root_dir /path/to/hptr/outpu
 
 
 <p align="center">
-  <img src="./res/plots/examples/example_default_1.png" width="33%" alt="example_1" />
-  <img src="./res/plots/examples/example_default_2.png" width="33%" alt="example_2" />
-  <img src="./res/plots/examples/example_default_3.png" width="33%" alt="example_3" />
+  <img src="./res/plots/examples/example_default_1.png" width="32%" alt="example_1" />
+  <img src="./res/plots/examples/example_default_2.png" width="32%" alt="example_2" />
+  <img src="./res/plots/examples/example_default_3.png" width="32%" alt="example_3" />
 </p>
 <p align="center">
   <em>NuScenes examples of default mode scenario <a href="https://github.com/zhejz/HPTR">HPTR</a>  outputs.</em>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "h5py==3.12.1",
     "tqdm==4.67.1",
     "matplotlib==3.8.4",
+    "shapely==2.0.7",
 ]
 
 [project.urls]

--- a/src/utils.py
+++ b/src/utils.py
@@ -80,4 +80,4 @@ def get_num_predict(
         NUM_PREDICT_ROLES: int
     """
 
-    return sum(role)[:][2]
+    return int(role[:, 2].sum())

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,57 @@
 import numpy as np
+from shapely.geometry import Polygon
+
+def get_corners(pos, size, yaw):
+        
+        dx =  size[0]/2 * np.cos(yaw)
+        dy =  size[0]/2 * np.sin(yaw)
+        wx =  size[1]/2 * -np.sin(yaw)
+        wy =  size[1]/2 *  np.cos(yaw)
+
+        return np.array([
+            [pos[:,0:1] + dx + wx, pos[:,1:2] + dy + wy],
+            [pos[:,0:1] + dx - wx, pos[:,1:2] + dy - wy],
+            [pos[:,0:1] - dx - wx, pos[:,1:2] - dy - wy],
+            [pos[:,0:1] - dx + wx, pos[:,1:2] - dy + wy],
+        ]).transpose(2,0,1,3).squeeze(-1)
+
+def overlaps(
+        target: int,
+        hptr_data: dict,
+        iou_thresh: float= 0.03,
+        current_step: int=10
+    ):
+
+    target_pos = hptr_data["agent/pos"][:, target] # (91, 2) x,y
+    target_yaw = hptr_data["agent/yaw_bbox"][:, target] # (91, 1) yaw
+    target_size = hptr_data["agent/size"][target] # (3) h,w,d
+
+    for i in range(hptr_data["agent/pos"].shape[1]):
+
+        if i == target:
+            continue
+
+        other_pos = hptr_data["agent/pos"][:, i] # (91, 2) x,y
+        other_yaw = hptr_data["agent/yaw_bbox"][:, i] # (91, 1) yaw
+        other_size = hptr_data["agent/size"][i] # (91, 3) h,w,d
+
+        target_box = get_corners(target_pos, target_size, target_yaw) # (91, 4, 2)
+        other_box = get_corners(other_pos, other_size, other_yaw) # (91, 4, 2)
+
+        
+        poly1 = Polygon(target_box[current_step,...])
+        poly2 = Polygon(other_box[current_step,...])
+
+        inter = poly1.intersection(poly2).area
+        union = poly1.union(poly2).area
+        if union != 0:
+            iou = inter/union
+        else:
+            iou = 0
+
+        if iou >= iou_thresh:
+            return True
+    return False
 
 
 def classify_track(


### PR DESCRIPTION
## Problem

Before this change, only one agent was ever marked for prediction (`[False, False, True]`), which left other valid agents unflagged.

## Solution

I now assign roles in three different rounds to ensure capturing as many valid prediction targets (up to 8) as possible, while prioritizing the ego-vehicle and the `to_predict` Unitraj agent.

1. **Primary assignment**  
   - **Ego-vehicle**: Marked as both `to_predict` and `sdc` (`[True, False, True]`) if it has valid past, current and future data.  
   - **Unitraj agent**: Its `to_predict` flag is set to `[False, False, True]` under the same validity criteria.

2. **Keypoints (optional)**  
   - Only executed when keypoints are relevant to the dataset generation.

3. **Fill remaining targets**  
   - Populate any remaining slots (up to 8), giving priority to the ego-vehicle and the Unitraj `to_predict` agent.

This three-round approach guarantees that the most important agents are captured before filling out the rest of the prediction batch. 
